### PR TITLE
fix(exports): resolve exports for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "dist/index.d.ts",
   "bin": "cli.js",
   "exports": {
-    "import": "./dist/index.js"
+    ".": "./dist/index.js"
   },
   "scripts": {
     "test": "npx tsx --test src/*.spec.ts",


### PR DESCRIPTION
Importing in node 22 and above throws an `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]` error.

# Steps to Reproduce

1. Confirm node v22
   ```
   $ node --version
     v22.5.1
   ```
1. Install e118-iin-list:
    ```
    $ npm install e118-iin-list
    ```
1. Require the package:
    ```
    $ node --eval "require('e118-iin-list')"
      node:internal/modules/cjs/loader:635
         throw e;
         ^

      Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined
    ```
    
# Resolution
Change the exports path from `import` to `.`.